### PR TITLE
Add CRUD API and styled React pages

### DIFF
--- a/backend/src/main/java/com/example/backend/DataController.java
+++ b/backend/src/main/java/com/example/backend/DataController.java
@@ -1,0 +1,42 @@
+package com.example.backend;
+
+import com.example.backend.data.DataRecord;
+import com.example.backend.data.DataService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/data")
+@CrossOrigin(origins = "http://localhost:3000")
+public class DataController {
+    private final DataService service;
+
+    public DataController(DataService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<DataRecord> all() {
+        return service.getAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<DataRecord> add(@RequestBody DataRecord record) throws IOException {
+        return ResponseEntity.ok(service.add(record));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DataRecord> update(@PathVariable int id, @RequestBody DataRecord record) throws IOException {
+        return service.update(id, record)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) throws IOException {
+        return service.delete(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/backend/src/main/java/com/example/backend/HelloController.java
+++ b/backend/src/main/java/com/example/backend/HelloController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = "http://localhost:3000")
 public class HelloController {
     @GetMapping("/api/hello")
     public Map<String, String> hello() {

--- a/backend/src/main/java/com/example/backend/data/DataRecord.java
+++ b/backend/src/main/java/com/example/backend/data/DataRecord.java
@@ -1,0 +1,40 @@
+package com.example.backend.data;
+
+public class DataRecord {
+    private int id;
+    private String name;
+    private int value;
+
+    public DataRecord() {
+    }
+
+    public DataRecord(int id, String name, int value) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/example/backend/data/DataService.java
+++ b/backend/src/main/java/com/example/backend/data/DataService.java
@@ -1,0 +1,74 @@
+package com.example.backend.data;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DataService {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private List<DataRecord> records = new ArrayList<>();
+    private Path dataFile;
+
+    @PostConstruct
+    public void init() throws IOException {
+        dataFile = Path.of("src/main/resources/data.json");
+        load();
+    }
+
+    public synchronized List<DataRecord> getAll() {
+        return new ArrayList<>(records);
+    }
+
+    public synchronized DataRecord add(DataRecord record) throws IOException {
+        int newId = records.stream().mapToInt(DataRecord::getId).max().orElse(0) + 1;
+        record.setId(newId);
+        records.add(record);
+        save();
+        return record;
+    }
+
+    public synchronized Optional<DataRecord> update(int id, DataRecord record) throws IOException {
+        for (int i = 0; i < records.size(); i++) {
+            if (records.get(i).getId() == id) {
+                record.setId(id);
+                records.set(i, record);
+                save();
+                return Optional.of(record);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public synchronized boolean delete(int id) throws IOException {
+        boolean removed = records.removeIf(r -> r.getId() == id);
+        if (removed) {
+            save();
+        }
+        return removed;
+    }
+
+    private void load() throws IOException {
+        if (Files.exists(dataFile)) {
+            try (InputStream in = Files.newInputStream(dataFile)) {
+                records = mapper.readValue(in, new TypeReference<List<DataRecord>>() {});
+            }
+        }
+    }
+
+    private void save() throws IOException {
+        try (OutputStream out = Files.newOutputStream(dataFile)) {
+            mapper.writerWithDefaultPrettyPrinter().writeValue(out, records);
+        }
+    }
+}

--- a/backend/src/main/resources/data.json
+++ b/backend/src/main/resources/data.json
@@ -1,0 +1,4 @@
+[
+  {"id": 1, "name": "Alpha", "value": 100},
+  {"id": 2, "name": "Beta", "value": 200}
+]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0",
+    "styled-components": "^6.1.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,3 @@
 .App {
   font-family: sans-serif;
-  text-align: center;
-  margin-top: 2rem;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,17 @@
-import { useEffect, useState } from 'react'
-import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Header from './components/Header.jsx';
+import Home from './components/Home.jsx';
+import DataTable from './components/DataTable.jsx';
+import './App.css';
 
-function App() {
-  const [message, setMessage] = useState('Loading...')
-
-  useEffect(() => {
-    fetch('/api/hello')
-      .then(res => res.json())
-      .then(data => setMessage(data.message))
-      .catch(() => setMessage('Error fetching message'))
-  }, [])
-
+export default function App() {
   return (
-    <div className="App">
-      <h1>{message}</h1>
-    </div>
-  )
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/data" element={<DataTable />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
-
-export default App

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  padding: 2rem;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  td, th { border: 1px solid #ccc; padding: 0.5rem; }
+`;
+
+export default function DataTable() {
+  const [rows, setRows] = useState([]);
+  const [form, setForm] = useState({ name: '', value: '' });
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    fetch('/api/data')
+      .then(res => res.json())
+      .then(setRows)
+      .catch(() => setError('Failed to load data'));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const addRow = e => {
+    e.preventDefault();
+    fetch('/api/data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: form.name, value: Number(form.value) })
+    }).then(load);
+  };
+
+  const updateRow = (id, data) => {
+    fetch(`/api/data/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(load);
+  };
+
+  const deleteRow = id => {
+    fetch(`/api/data/${id}`, { method: 'DELETE' }).then(load);
+  };
+
+  return (
+    <Wrapper>
+      <h1>Data Table</h1>
+      {error && <p>{error}</p>}
+      <form onSubmit={addRow} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <input
+          placeholder="Value"
+          type="number"
+          value={form.value}
+          onChange={e => setForm({ ...form, value: e.target.value })}
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+      <Table>
+        <thead>
+          <tr><th>ID</th><th>Name</th><th>Value</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.id}>
+              <td>{r.id}</td>
+              <td>
+                <input defaultValue={r.name} onBlur={e => updateRow(r.id, { ...r, name: e.target.value })} />
+              </td>
+              <td>
+                <input type="number" defaultValue={r.value} onBlur={e => updateRow(r.id, { ...r, value: Number(e.target.value) })} />
+              </td>
+              <td><button onClick={() => deleteRow(r.id)}>Delete</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Wrapper>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Bar = styled.header`
+  background: linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%);
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Nav = styled.nav`
+  a {
+    margin: 0 1rem;
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
+  }
+`;
+
+export default function Header() {
+  return (
+    <Bar>
+      <h2 style={{ margin: 0, color: 'white' }}>My App</h2>
+      <Nav>
+        <Link to="/">Home</Link>
+        <Link to="/data">Data Table</Link>
+      </Nav>
+    </Bar>
+  );
+}

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 60px);
+  background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+  color: #fff;
+  text-align: center;
+`;
+
+const Button = styled.button`
+  background: #fff;
+  color: #333;
+  border: none;
+  padding: 0.8rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+`;
+
+export default function Home() {
+  return (
+    <Wrapper>
+      <h1>Life is Beautiful</h1>
+      <p>Embrace the wonders of nature and live vibrantly.</p>
+      <Button>Learn More</Button>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- implement CRUD endpoints backed by `data.json`
- enable CORS for localhost:3000
- add React Router and styled components
- create header, home page and editable data table
- update dependencies

## Testing
- `gradle test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869030068908328bbabad3aeabeb468