### PR TITLE
Fix backend CORS origin

### DIFF
--- a/backend/src/main/java/com/example/backend/DataController.java
+++ b/backend/src/main/java/com/example/backend/DataController.java
@@ -10,7 +10,8 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/data")
-@CrossOrigin(origins = "http://localhost:3000")
+// The React frontend runs via Vite on port 5173 during development
+@CrossOrigin(origins = "http://localhost:5173")
 public class DataController {
     private final DataService service;
 

--- a/backend/src/main/java/com/example/backend/HelloController.java
+++ b/backend/src/main/java/com/example/backend/HelloController.java
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
-@CrossOrigin(origins = "http://localhost:3000")
+// Vite serves the frontend on port 5173, so allow requests from that origin
+@CrossOrigin(origins = "http://localhost:5173")
 public class HelloController {
     @GetMapping("/api/hello")
     public Map<String, String> hello() {


### PR DESCRIPTION
## Summary
- allow cross-origin requests from Vite dev server port

## Testing
- `npm install`
- `npm run lint`
- `/tmp/gradle8/gradle-8.4/bin/gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6869057d3aac8328afe70ab77595fc8e