### PR TITLE
Improve backend code and add unit tests

### DIFF
--- a/backend/src/main/java/com/example/backend/data/DataRecord.java
+++ b/backend/src/main/java/com/example/backend/data/DataRecord.java
@@ -37,4 +37,26 @@ public class DataRecord {
     public void setValue(int value) {
         this.value = value;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataRecord that = (DataRecord) o;
+        return id == that.id && value == that.value && java.util.Objects.equals(label, that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(id, label, value);
+    }
+
+    @Override
+    public String toString() {
+        return "DataRecord{" +
+                "id=" + id +
+                ", label='" + label + '\'' +
+                ", value=" + value +
+                '}';
+    }
 }

--- a/backend/src/test/java/com/example/backend/data/DataServiceTest.java
+++ b/backend/src/test/java/com/example/backend/data/DataServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.backend.data;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataServiceTest {
+
+    private Path tempFile;
+    private DataService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempFile = Files.createTempFile("data", ".json");
+        Files.writeString(tempFile, "[]");
+        service = new DataService(tempFile, new ObjectMapper());
+        service.init();
+    }
+
+    @Test
+    void addAssignsIncrementingIds() throws IOException {
+        DataRecord record = new DataRecord(0, "test", 123);
+        DataRecord saved = service.add(record);
+        assertEquals(1, saved.getId());
+        assertEquals(saved, record);
+    }
+
+    @Test
+    void getAllReturnsCopy() throws IOException {
+        service.add(new DataRecord(0, "a", 1));
+        List<DataRecord> list = service.getAll();
+        list.clear();
+        assertEquals(1, service.getAll().size());
+    }
+
+    @Test
+    void updateReturnsUpdatedRecordWhenExists() throws IOException {
+        DataRecord record = service.add(new DataRecord(0, "a", 1));
+        DataRecord updated = new DataRecord(0, "b", 2);
+        Optional<DataRecord> result = service.update(record.getId(), updated);
+        assertTrue(result.isPresent());
+        assertEquals("b", result.get().getLabel());
+        assertEquals(record.getId(), result.get().getId());
+    }
+
+    @Test
+    void updateReturnsEmptyWhenRecordMissing() throws IOException {
+        Optional<DataRecord> result = service.update(42, new DataRecord());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void deleteRemovesRecord() throws IOException {
+        DataRecord record = service.add(new DataRecord(0, "a", 1));
+        assertTrue(service.delete(record.getId()));
+        assertFalse(service.delete(record.getId()));
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `DataService` for dependency injection and cleaner persistence logic
- add equality methods to `DataRecord`
- add `DataServiceTest` unit tests

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68690a68d4b88328967a9067ffaea06a