### PR TITLE
Improve layout and add theme switch

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,17 +1,52 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useState } from 'react';
+import { ThemeProvider, createGlobalStyle } from 'styled-components';
 import Header from './components/Header.jsx';
 import Home from './components/Home.jsx';
 import DataTable from './components/DataTable.jsx';
 import './App.css';
 
+const GlobalStyle = createGlobalStyle`
+  body {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    place-items: center;
+    background-color: ${props => props.theme.body};
+    color: ${props => props.theme.text};
+    font-family: system-ui, sans-serif;
+    transition: background-color 0.3s ease;
+  }
+`;
+
+const lightTheme = {
+  body: '#ffffff',
+  text: '#213547',
+  header: 'linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%)',
+  primary: '#66a6ff'
+};
+
+const darkTheme = {
+  body: '#242424',
+  text: '#ffffff',
+  header: 'linear-gradient(135deg, #141e30 0%, #243b55 100%)',
+  primary: '#243b55'
+};
+
 export default function App() {
+  const [themeName, setThemeName] = useState('light');
+  const theme = themeName === 'light' ? lightTheme : darkTheme;
+  const toggleTheme = () => setThemeName(t => (t === 'light' ? 'dark' : 'light'));
+
   return (
-    <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/data" element={<DataTable />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <BrowserRouter>
+        <Header onToggleTheme={toggleTheme} />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/data" element={<DataTable />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -2,11 +2,15 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  display: grid;
+  place-items: center;
+  gap: 1rem;
   padding: 2rem;
 `;
 
 const Table = styled.table`
   width: 100%;
+  max-width: 600px;
   border-collapse: collapse;
   td, th { border: 1px solid #ccc; padding: 0.5rem; }
 `;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -2,13 +2,17 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Bar = styled.header`
-  background: linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%);
+  background: ${props => props.theme.header};
   padding: 1rem;
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  width: 100%;
 `;
 
 const Nav = styled.nav`
+  display: flex;
+  align-items: center;
   a {
     margin: 0 1rem;
     color: white;
@@ -17,13 +21,24 @@ const Nav = styled.nav`
   }
 `;
 
-export default function Header() {
+const ToggleButton = styled.button`
+  margin-left: 1rem;
+  background: transparent;
+  border: 2px solid white;
+  color: white;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+`;
+
+export default function Header({ onToggleTheme }) {
   return (
     <Bar>
       <h2 style={{ margin: 0, color: 'white' }}>My App</h2>
       <Nav>
         <Link to="/">Home</Link>
         <Link to="/data">Data Table</Link>
+        <ToggleButton onClick={onToggleTheme}>Toggle</ToggleButton>
       </Nav>
     </Bar>
   );

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,19 +1,16 @@
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: calc(100vh - 60px);
-  background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
-  color: #fff;
+  display: grid;
+  place-items: center;
+  gap: 1rem;
   text-align: center;
+  padding: 2rem;
 `;
 
 const Button = styled.button`
-  background: #fff;
-  color: #333;
+  background: ${props => props.theme.primary};
+  color: #fff;
   border: none;
   padding: 0.8rem 1.5rem;
   font-size: 1rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- centralize layout using CSS grid
- add light/dark theme toggle via styled-components
- tweak Header, Home, DataTable components for grid design
- refine global styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68690c04b6208328846afdb584f2e86c