### PR TITLE
Add editable data table with persisted DataItem

### DIFF
--- a/backend/src/main/java/com/example/backend/DataController.java
+++ b/backend/src/main/java/com/example/backend/DataController.java
@@ -1,6 +1,6 @@
 package com.example.backend;
 
-import com.example.backend.data.DataRecord;
+import com.example.backend.data.DataItem;
 import com.example.backend.data.DataService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,17 +19,17 @@ public class DataController {
     }
 
     @GetMapping
-    public List<DataRecord> all() {
+    public List<DataItem> all() {
         return service.getAll();
     }
 
     @PostMapping
-    public ResponseEntity<DataRecord> add(@RequestBody DataRecord record) throws IOException {
+    public ResponseEntity<DataItem> add(@RequestBody DataItem record) throws IOException {
         return ResponseEntity.ok(service.add(record));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<DataRecord> update(@PathVariable int id, @RequestBody DataRecord record) throws IOException {
+    public ResponseEntity<DataItem> update(@PathVariable int id, @RequestBody DataItem record) throws IOException {
         return service.update(id, record)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());

--- a/backend/src/main/java/com/example/backend/data/DataItem.java
+++ b/backend/src/main/java/com/example/backend/data/DataItem.java
@@ -1,14 +1,14 @@
 package com.example.backend.data;
 
-public class DataRecord {
+public class DataItem {
     private int id;
     private String label;
-    private int value;
+    private String value;
 
-    public DataRecord() {
+    public DataItem() {
     }
 
-    public DataRecord(int id, String label, int value) {
+    public DataItem(int id, String label, String value) {
         this.id = id;
         this.label = label;
         this.value = value;
@@ -30,11 +30,11 @@ public class DataRecord {
         this.label = label;
     }
 
-    public int getValue() {
+    public String getValue() {
         return value;
     }
 
-    public void setValue(int value) {
+    public void setValue(String value) {
         this.value = value;
     }
 
@@ -42,8 +42,8 @@ public class DataRecord {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DataRecord that = (DataRecord) o;
-        return id == that.id && value == that.value && java.util.Objects.equals(label, that.label);
+        DataItem that = (DataItem) o;
+        return id == that.id && java.util.Objects.equals(label, that.label) && java.util.Objects.equals(value, that.value);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class DataRecord {
 
     @Override
     public String toString() {
-        return "DataRecord{" +
+        return "DataItem{" +
                 "id=" + id +
                 ", label='" + label + '\'' +
                 ", value=" + value +

--- a/backend/src/main/java/com/example/backend/data/DataService.java
+++ b/backend/src/main/java/com/example/backend/data/DataService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +20,7 @@ import java.util.Optional;
 public class DataService {
     private final ObjectMapper mapper;
     private final Path dataFile;
-    private final List<DataRecord> records = new ArrayList<>();
+    private final List<DataItem> records = new ArrayList<>();
     private final java.util.concurrent.atomic.AtomicInteger lastId = new java.util.concurrent.atomic.AtomicInteger();
 
     @org.springframework.beans.factory.annotation.Autowired
@@ -36,15 +37,15 @@ public class DataService {
     @PostConstruct
     public void init() throws IOException {
         load();
-        int maxId = records.stream().mapToInt(DataRecord::getId).max().orElse(0);
+        int maxId = records.stream().mapToInt(DataItem::getId).max().orElse(0);
         lastId.set(maxId);
     }
 
-    public synchronized List<DataRecord> getAll() {
+    public synchronized List<DataItem> getAll() {
         return new ArrayList<>(records);
     }
 
-    public synchronized DataRecord add(DataRecord record) throws IOException {
+    public synchronized DataItem add(DataItem record) throws IOException {
         int newId = lastId.incrementAndGet();
         record.setId(newId);
         records.add(record);
@@ -52,7 +53,7 @@ public class DataService {
         return record;
     }
 
-    public synchronized Optional<DataRecord> update(int id, DataRecord record) throws IOException {
+    public synchronized Optional<DataItem> update(int id, DataItem record) throws IOException {
         for (int i = 0; i < records.size(); i++) {
             if (records.get(i).getId() == id) {
                 record.setId(id);
@@ -76,7 +77,7 @@ public class DataService {
         if (Files.exists(dataFile)) {
             try (InputStream in = Files.newInputStream(dataFile)) {
                 records.clear();
-                records.addAll(mapper.readValue(in, new TypeReference<List<DataRecord>>() {}));
+                records.addAll(mapper.readValue(in, new TypeReference<List<DataItem>>() {}));
             }
         }
     }

--- a/backend/src/main/resources/data.json
+++ b/backend/src/main/resources/data.json
@@ -1,4 +1,4 @@
 [
-  {"id": 1, "label": "Alpha", "value": 100},
-  {"id": 2, "label": "Beta", "value": 200}
+  {"id": 1, "label": "Alpha", "value": "100"},
+  {"id": 2, "label": "Beta", "value": "200"}
 ]

--- a/backend/src/test/java/com/example/backend/data/DataServiceTest.java
+++ b/backend/src/test/java/com/example/backend/data/DataServiceTest.java
@@ -27,25 +27,25 @@ class DataServiceTest {
 
     @Test
     void addAssignsIncrementingIds() throws IOException {
-        DataRecord record = new DataRecord(0, "test", 123);
-        DataRecord saved = service.add(record);
+        DataItem record = new DataItem(0, "test", "123");
+        DataItem saved = service.add(record);
         assertEquals(1, saved.getId());
         assertEquals(saved, record);
     }
 
     @Test
     void getAllReturnsCopy() throws IOException {
-        service.add(new DataRecord(0, "a", 1));
-        List<DataRecord> list = service.getAll();
+        service.add(new DataItem(0, "a", "1"));
+        List<DataItem> list = service.getAll();
         list.clear();
         assertEquals(1, service.getAll().size());
     }
 
     @Test
     void updateReturnsUpdatedRecordWhenExists() throws IOException {
-        DataRecord record = service.add(new DataRecord(0, "a", 1));
-        DataRecord updated = new DataRecord(0, "b", 2);
-        Optional<DataRecord> result = service.update(record.getId(), updated);
+        DataItem record = service.add(new DataItem(0, "a", "1"));
+        DataItem updated = new DataItem(0, "b", "2");
+        Optional<DataItem> result = service.update(record.getId(), updated);
         assertTrue(result.isPresent());
         assertEquals("b", result.get().getLabel());
         assertEquals(record.getId(), result.get().getId());
@@ -53,13 +53,13 @@ class DataServiceTest {
 
     @Test
     void updateReturnsEmptyWhenRecordMissing() throws IOException {
-        Optional<DataRecord> result = service.update(42, new DataRecord());
+        Optional<DataItem> result = service.update(42, new DataItem());
         assertTrue(result.isEmpty());
     }
 
     @Test
     void deleteRemovesRecord() throws IOException {
-        DataRecord record = service.add(new DataRecord(0, "a", 1));
+        DataItem record = service.add(new DataItem(0, "a", "1"));
         assertTrue(service.delete(record.getId()));
         assertFalse(service.delete(record.getId()));
     }


### PR DESCRIPTION
## Summary
- switch backend model to `DataItem` with string value
- persist items in `data.json`
- expose CRUD endpoints using `DataItem`
- update unit tests for new model
- display editable table in React with ID column and edit/save/delete actions

## Testing
- `gradle clean test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68690e15984483288d0d5154f62133ad